### PR TITLE
WIP: fix missing color on older terminals

### DIFF
--- a/gocat.go
+++ b/gocat.go
@@ -162,11 +162,7 @@ func (gc *GoCat) scoreSomeNip(farg string) error {
 // the bomb-ass Nip you just scored and that Time of the
 // Nip is fast approaching so they better come the fuck on..
 func (gc *GoCat) gatherHomies(f, l, s string) {
-	fmatter := formatters.TTY16m
-	if fmatter == nil {
-		fmatter = formatters.TTY256
-	}
-
+    fmatter := formatters.Get("terminal256")
 	gc.fmatter = fmatter
 
 	// -----


### PR DESCRIPTION
Changes the formatter to `terminal256` so that colorization works on older terminal emulators. 

Feel free to reject this PR since it breaks True Color support. The logic from https://github.com/chalk/supports-color/blob/master/index.js could be adapted to determine color support.